### PR TITLE
Update launcher.py w/ battery bar

### DIFF
--- a/badger_os/launcher.py
+++ b/badger_os/launcher.py
@@ -1,9 +1,14 @@
+from machine import ADC, I2C, Pin
 import gc
+import re
 import os
 import time
 import math
 import badger2040
+from badger2040 import WIDTH
 import badger_os
+if badger2040.is_wireless() == True:
+    import network
 import jpegdec
 
 APP_DIR = "/examples"
@@ -42,8 +47,6 @@ centers = (41, 147, 253)
 
 MAX_PAGE = math.ceil(len(examples) / 3)
 
-WIDTH = 296
-
 
 def map_value(input, in_min, in_max, out_min, out_max):
     return (((input - in_min) * (out_max - out_min)) / (in_max - in_min)) + out_min
@@ -79,6 +82,139 @@ def draw_disk_usage(x):
     display.text("{:.2f}%".format(f_used), x + 91, 4, WIDTH, 1.0)
 
 
+def draw_battery_usage(x):
+
+    # Pico W voltage read function by darconeous on reddit with a little help of Kerry Waterfield aka alphanumeric: 
+    # https://www.reddit.com/r/raspberrypipico/comments/xalach/comment/ipigfzu/
+    # in reference of https://pico.pinout.xyz/ and https://picow.pinout.xyz/
+    # the pins and ports are transfered, to make it work on a badger2040 non-W
+         
+    # these are our reference voltages for a full/empty battery, in volts 
+    # the values could vary by battery size/manufacturer so you might need to adjust them
+    # full/empty-pairs for some batteries:
+    # lipo: 4.2 / 2.8
+    # 2xAA/2xAAA alkaline: 3.2 / 2.4
+    full_battery = 4.2 
+    empty_battery = 2.8 
+    vsys = 0
+
+    conversion_factor = 3 * 3.3 / 2**16  # for Badger 2040W internal 3.3V as referece
+    little_wait = 0.01  # time slice to wait for vref to stabilize
+
+    if badger2040.is_wireless() == True:
+        
+        wlan = network.WLAN(network.STA_IF)
+        wlan_active = wlan.active()
+    
+        try:
+            # Don't use the WLAN chip for a moment.
+            wlan.active(False)
+            
+        
+            # Make sure pin 25 is high.
+            Pin(25, mode=Pin.OUT, pull=Pin.PULL_DOWN).high()
+  
+            # Reconfigure pin 29 as an input.
+            Pin(29, Pin.IN, pull=None)
+
+            # reading 'WL_GPIO2' on a picoW tells us whether or not USB power is connected (VBUS Sense)
+            # be aware, that on MicroPython v0.0.4 there is a bug and it doesnt work! Stay on v0.0.3!
+            vbus = Pin('WL_GPIO2', Pin.IN).value()
+
+            # doing one shot for free
+            vsys_sample = ADC(29).read_u16() * conversion_factor
+            time.sleep(10 * little_wait)
+            
+            # we will read 5 times 
+            for i in range(5):
+                # reading vsys aka battery-level
+                vsys_sample = ADC(29).read_u16() * conversion_factor
+                vsys = vsys + vsys_sample
+                time.sleep(5 * little_wait)
+
+            # arithmetic average over the 5 samples
+            vsys = ( vsys / 5 )
+                    
+        finally:
+
+            # Restore the pin state and possibly reactivate WLAN
+            Pin(25, Pin.OUT, value=0, pull=Pin.PULL_DOWN)
+            Pin(29, Pin.ALT, pull=Pin.PULL_DOWN, alt=7)
+            wlan.active(wlan_active)
+
+
+    else:
+        # Configure pin 29 as an input. (Read VSYS/3 through resistor divider and FET Q1)
+        Pin(25, mode=Pin.OUT, pull=Pin.PULL_DOWN).high()
+        Pin(29, Pin.IN, pull=None)
+        
+        # reading pin24 on a pico-non-w tells us whether or not USB power is connected (VBUS Sense)
+        vbus = Pin(24, Pin.IN).value()  
+        
+        # give vref a little time to stabilize
+        vsys_sample = ADC(29).read_u16() * conversion_factor
+        time.sleep(50 * little_wait) 
+
+        # we well read 5 times 
+        for i in range(5):
+            # reading vsys aka battery-level
+            vsys_sample = ADC(29).read_u16() * conversion_factor
+            vsys = vsys + vsys_sample
+            time.sleep(5 * little_wait) 
+        
+        # arithmetic average over the 5 samples
+        vsys = ( vsys / 5 )
+
+        
+    # convert the val_sys (raw ADC read) into a voltage, and then a percentage
+    b_level = 100 * ( ( vsys - empty_battery) / (full_battery - empty_battery) )
+    if b_level > 100:
+        b_level = 100.00
+
+    display.set_pen(15)
+    display.image(
+        bytearray(
+            (
+                0b110011,
+                0b001100,
+                0b011110,
+                0b011110,
+                0b010010,
+                0b010010,
+                0b010010,
+                0b011110,
+                0b000001,
+            )
+        ),
+        6,
+        9,
+        x,
+        3,
+    )
+    # assemble horizontal bar-graph beginning at position x+8 (bc. width of 6px the battery symbol)
+    # outer white box
+    display.rectangle(x + 8, 3, 80, 10)
+    display.set_pen(0)
+    # inner black box
+    display.rectangle(x + 9, 4, 78, 8)
+    # white bar according to percentage
+    display.set_pen(15)
+    #print(f"b_level: {b_level}")
+
+    # reading 'WL_GPIO2' on a picoW or pin 24 on pico tells us whether or not USB power is connected (VBUS Sense)
+
+    # if it's not plugged into USB power...
+    if vbus == False:
+        # if vbus is false, display the battery status:
+        # bar starts at coordinates x+10,5 and 6px high max length 76px (accordingly to percentage)
+        display.rectangle(x + 10, 5, int(76 / 100.0 * b_level), 6) 
+        display.text("{:.2f}%".format(b_level), x + 91, 4, WIDTH, 1.0)
+    else:
+        # fake full power on USB when "vbus" is true
+        display.rectangle(x + 10, 5, int(76 / 100.0 * 100 ), 6) 
+        display.text("USB", x + 91, 4, WIDTH, 1.0)
+
+
 def render():
     display.set_pen(15)
     display.clear()
@@ -109,7 +245,8 @@ def render():
 
     display.set_pen(0)
     display.rectangle(0, 0, WIDTH, 16)
-    draw_disk_usage(90)
+    draw_disk_usage(50)
+    draw_battery_usage(175)
     display.set_pen(15)
     display.text("badgerOS", 4, 4, WIDTH, 1.0)
 


### PR DESCRIPTION
pico and picoW (aka Badger2040 / BAgder 2040W) have different pin reference for vbus, vref. Also Badger 2040 (non-W) needs more time (50ms) to have stabilzed vref to show a usable reference value for 3.3V.